### PR TITLE
trio 0.19.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,30 +15,31 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
-    - attrs >=19.2.0
-    - sortedcontainers
     - async_generator >=1.9
+    - attrs >=19.2.0
+    - cffi >=1.14  # [win]
     - contextvars >=2.1  # [py<37]
     - idna
     - outcome
     - sniffio
-    - cffi >=1.14  # [win]
+    - sortedcontainers
 
 test:
   imports:
     - trio
-    - trio._core
-    - trio._core.tests
-    - trio._core.tests.test_multierror_scripts
     - trio.testing
     - trio.tests
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/python-trio/trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 895e318e5ec5e8cea9f60b473b6edb95b215e82d99556a03eb2d20c5e027efe1
 
 build:
-  skip: true  # [py<35]
+  skip: true  # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trio" %}
-{% set version = "0.18.0" %}
+{% set version = "0.19.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 87a66ae61f27fe500c9024926a9ba482c07e1e0f56380b70a264d19c435ba076
+  sha256: 895e318e5ec5e8cea9f60b473b6edb95b215e82d99556a03eb2d20c5e027efe1
 
 build:
   skip: true  # [py<35]


### PR DESCRIPTION
Update trio to 0.19.0

`anyio 3.5.0` requires trio 0.19.0 with python 3.10 support

Version change: bump version number from 0.18.0 to 0.19.0
Changelog: add python 3.10 support https://github.com/python-trio/trio/blob/master/docs/source/history.rst
Bug Tracker: new open issues https://github.com/python-trio/trio/issues
Upstream license:  License file:  https://github.com/python-trio/trio/blob/master/LICENSE
Upstream setup.py:  https://github.com/python-trio/trio/blob/master/setup.py

The package trio is mentioned inside the packages:
anyio | async_generator | ipykernel | ipython | outcome | sniffio | trustme |

Actions:
1. Skip py<36

Result:
- all-succeeded
