### PR TITLE
Trio 0.30.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trio-{{ version }}.tar.gz
   sha256: 0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df
+  patches:
+    - patches/filterwarnings.patch
 
 build:
   skip: true  # [py<39]
@@ -15,6 +17,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -41,10 +46,12 @@ test:
     - pytest
     - async_generator >= 1.9
     - astor
-    - isort         # for the ssl + DTLS tests
+    - isort
+    - pyopenssl >= 22.0.0   # for the ssl + DTLS tests
+    - trustme       # for the ssl + DTLS tests
   commands:
     - pip check
-    - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports -k "not test_dtls"
+    - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports --disable-warnings
 
 about:
   home: https://github.com/python-trio/trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - attrs >=23.2.0
-    - cffi >=1.14
+    - cffi >=1.14   # [win]
     - idna
     - outcome
     - sniffio >=1.3.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,13 +41,10 @@ test:
     - pytest
     - async_generator >= 1.9
     - astor
-    - isort
-    - pyopenssl
-    - cryptography  # for the ssl + DTLS tests
-    - trustme               # for the ssl + DTLS tests
+    - isort         # for the ssl + DTLS tests
   commands:
     - pip check
-    - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports
+    - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports -k "not test_dtls"
 
 about:
   home: https://github.com/python-trio/trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "trio" %}
-{% set version = "0.26.2" %}
+{% set version = "0.30.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trio-{{ version }}.tar.gz
-  sha256: 0346c3852c15e5c7d40ea15972c4805689ef2cb8b5206f794c9c19450119f3a4
+  sha256: 0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df
 
 build:
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -18,17 +18,17 @@ requirements:
   host:
     - python
     - pip
-    - setuptools >=64
+    - setuptools >=77
     - wheel
   run:
     - python
     - attrs >=23.2.0
-    - cffi >=1.14  # [win]
+    - cffi >=1.14
     - idna
     - outcome
     - sniffio >=1.3.0
     - sortedcontainers
-    - exceptiongroup # [py<311]
+    - exceptiongroup    # [py<311]
 
 test:
   source_files:
@@ -42,7 +42,7 @@ test:
     - async_generator >= 1.9
     - astor
     - isort
-    - pyopenssl >= 22.0.0   # for the ssl + DTLS tests
+    - pyopenssl >=22.0.0,<23.0.0   # for the ssl + DTLS tests
     - trustme               # for the ssl + DTLS tests
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trio-{{ version }}.tar.gz
   sha256: 0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df
+   # Ignore deprecation warnings from test dependencies (pyOpenSSL/trustme) that block test collection
   patches:
     - patches/filterwarnings.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ test:
     - async_generator >= 1.9
     - astor
     - isort
-    - pyopenssl >=22.0.0,<23.0.0
-    - cryptography >=35.0 # for the ssl + DTLS tests
+    - pyopenssl
+    - cryptography  # for the ssl + DTLS tests
     - trustme               # for the ssl + DTLS tests
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,8 @@ test:
     - async_generator >= 1.9
     - astor
     - isort
-    - pyopenssl >=22.0.0,<23.0.0   # for the ssl + DTLS tests
+    - pyopenssl >=22.0.0,<23.0.0
+    - cryptography >=35.0 # for the ssl + DTLS tests
     - trustme               # for the ssl + DTLS tests
   commands:
     - pip check

--- a/recipe/patches/filterwarnings.patch
+++ b/recipe/patches/filterwarnings.patch
@@ -1,0 +1,13 @@
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -9,6 +9,10 @@
+   'ignore:You are using cryptography on a 32-bit Python on a 64-bit Windows Operating System. Cryptography will be significantly faster if you switch to using a 64-bit Python.:UserWarning',
+   # https://github.com/berkerpeksag/astor/issues/217
+   'ignore:ast.Num is deprecated:DeprecationWarning:astor',
++  # Temporary ignores for pyOpenSSL deprecation warnings
++  'ignore:Passing pyOpenSSL PKey objects is deprecated. You should use a cryptography private key instead.:DeprecationWarning',
++  # Additional warning that appears during test collection
++  'ignore:Passing pyOpenSSL X509 objects is deprecated. You should use a cryptography.x509.Certificate instead.:DeprecationWarning',
+ ]
+ junit_family = "xunit2"
+ markers = ["redistributors_should_skip: tests that should be skipped by downstream redistributors"]


### PR DESCRIPTION
> ## ☆ Trio 0.30.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8164) 
[Upstream](https://github.com/python-trio/trio/tree/v0.30.0)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Added skip to python versions less than 3.8
> *  Updated `about` section 
> *  Added a patch to ignore deprecation warnings from pyOpenSSL and trustme dependencies that were causing test collection to fail, without affecting Trio's functionality.