### PR TITLE
trio 0.32.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,10 +62,7 @@ test:
     - astor
     - isort
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
-    - trustme  # for the ssl + DTLS tests
-    - ruff   # [unix]
-    - black  # [py<314 and unix]
-    - pyyaml    
+    - trustme  # for the ssl + DTLS tests 
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,8 +63,9 @@ test:
     - isort
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
     - trustme  # for the ssl + DTLS tests
-    - ruff
-    - pyyaml
+    - ruff   # [unix]
+    - black  # [py<314 and unix]
+    - pyyaml    
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,26 +1,23 @@
 {% set name = "trio" %}
-{% set version = "0.30.0" %}
+{% set version = "0.32.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/trio-{{ version }}.tar.gz
-  sha256: 0781c857c0c81f8f51e0089929a26b5bb63d57f927728a5586f7e36171f064df
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 150f29ec923bcd51231e1d4c71c7006e65247d68759dd1c19af4ea815a25806b
   # Ignore deprecation warnings from test dependencies (pyOpenSSL/trustme) that block test collection
   patches:
     - patches/filterwarnings.patch
 
 build:
-  skip: true  # [py<39]
-  number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: true  # [py<310]
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
-  build:
-    - patch  # [not win]
-    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -41,30 +38,50 @@ test:
     - pyproject.toml
   imports:
     - trio
+    - trio._channel
+    - trio._core
+    - trio._dtls
+    - trio._file_io
+    - trio._highlevel_open_tcp_stream
+    - trio._highlevel_open_unix_stream
+    - trio._repl
+    - trio._socket
+    - trio._ssl
+    - trio._tests
+    - trio._tools
+    - trio._util
+    - trio.abc
+    - trio.lowlevel
+    - trio.socket
     - trio.testing
+    - trio.to_thread
   requires:
     - pip
-    - pytest
-    - async_generator >= 1.9
+    - pytest >=8.4
+    - async_generator >=1.9
     - astor
     - isort
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
     - trustme  # for the ssl + DTLS tests
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # Skip test_dtls.py because it raises a DeprecationWarning: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception
     - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports --disable-warnings --deselect=_tests/test_dtls.py
 
 about:
   home: https://github.com/python-trio/trio
-  license: MIT
-  license_family: MIT
-  license_file: LICENSE
-  summary: Trio – a friendly Python library for async concurrency and I/O
+  license: MIT AND Apache-2.0
+  license_family: Other
+  license_file:
+    - LICENSE.APACHE2
+    - LICENSE.MIT
+    - LICENSE
+  summary: A friendly Python library for async concurrency and I/O
   description: |
     The Trio project aims to produce a production-quality, permissively licensed,
     async/await-native I/O library for Python.
-  doc_url: https://trio.readthedocs.io/
+  doc_url: https://trio.readthedocs.io
   dev_url: https://github.com/python-trio/trio
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,11 +63,14 @@ test:
     - isort
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
     - trustme  # for the ssl + DTLS tests
+    - ruff
+    - black
+    - pyyaml
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # Skip test_dtls.py because it raises a DeprecationWarning: Attempting to mutate a Context after a Connection was created. In the future, this will raise an exception
-    - python -m pytest --pyargs trio -ra --durations=10 -m "not redistributors_should_skip" --skip-optional-imports --disable-warnings --deselect=_tests/test_dtls.py
+    - python -m pytest --pyargs trio -ra -v --durations=10 -k "not slow and not redistributors_should_skip" --skip-optional-imports --disable-warnings --deselect=_tests/test_dtls.py
 
 about:
   home: https://github.com/python-trio/trio

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,18 +38,6 @@ test:
     - pyproject.toml
   imports:
     - trio
-    - trio._channel
-    - trio._core
-    - trio._dtls
-    - trio._file_io
-    - trio._highlevel_open_tcp_stream
-    - trio._highlevel_open_unix_stream
-    - trio._repl
-    - trio._socket
-    - trio._ssl
-    - trio._tests
-    - trio._tools
-    - trio._util
     - trio.abc
     - trio.lowlevel
     - trio.socket

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ test:
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
     - trustme  # for the ssl + DTLS tests
     - ruff
-    - black
+    - black  # [py<314]
     - pyyaml
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,6 @@ test:
     - pyopenssl >= 22.0.0  # for the ssl + DTLS tests
     - trustme  # for the ssl + DTLS tests
     - ruff
-    - black  # [py<314]
     - pyyaml
   commands:
     - pip check


### PR DESCRIPTION
trio 0.32.0 

**Destination channel:** Defaults

### Links

- [PKG-10555]
- dev_url:        https://github.com/python-trio/trio/tree/v0.32.0
- conda_forge:    https://github.com/conda-forge/trio-feedstock
- pypi:           https://pypi.org/project/trio/0.32.0
- pypi inspector: https://inspector.pypi.io/project/trio/0.32.0

### Explanation of changes:

- new version number 0.30.0 → 0.32.0
- python skip condition changed from [py<39] → [py<310]
- updated test imports, added more cover
- license changed from single MIT → MIT AND Apache-2.0


[PKG-10555]: https://anaconda.atlassian.net/browse/PKG-10555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ